### PR TITLE
Fixes #6: Constants should be upper-case.

### DIFF
--- a/src/main/help/expressions.html
+++ b/src/main/help/expressions.html
@@ -24,7 +24,7 @@
                                 </ol>
                             </li>
                             <li><a href="#arrays">Arrays</a></li>
-                            <li><a href="#predefined-variables">Predefined Variables</a></li>
+                            <li><a href="#constants">Constants</a></li>
                         </ol>
                     </li>
                     <li><a href="#operators">Operators</a>
@@ -60,7 +60,7 @@
                 <p>A variable starts with an alphabetic character. This character can be followed by any number of letters, digits, or underscores.</p>
                 <p>Variables are created when they are first assigned a value. The type of variable is the same as the type of the value assigned to it. This type could change in a future assignment.</p>
                 <h2><a id="static-variables"></a>Static Variables</h2>
-                <p>When a script is first loaded, there are no variables defined; variables are created as they are assigned their first value. Under some circumstances (for example, animation) a script may be re-executed without being re-loaded. For most variables, there is no difference between the first execution (when the script is loaded) and any subsequent execution—the script begins with a clean slate.</p>
+              <p>When a script is first loaded, there are no variables defined; variables are created as they are assigned their first value. Under some circumstances (for example, animation) a script may be re-executed without being re-loaded. For most variables, there is no difference between the first execution (when the script is loaded) and any subsequent execution—the script begins with a clean slate.</p>
                 <p>Static variables are one exception; once created, they retain their values across script executions (but not across script loads). Once a variable is marked as static, it remains static and can be used like any other variable.</p>
                 <p>To initialize a static variable only once requires knowing if it exists. The <span class="literal">defined()</span> function allows you to find out without generating an error if the variable doesn't yet exist.</p>
                 <h2><a id="dynamic-variables"></a>Dynamic Variables</h2>
@@ -76,14 +76,15 @@
                 <p>If the expression evaluates to a string, the string is prefixed with a dollar sign and appended to the variable's name. </p>
                 <p> This creates a new name. Other than having the name created dynamically, the variable operates like any other variable. Note that it is impossible to create these variable names directly since the dollar sign is not valid in variable names. Note also that, following the rules above, a[1] would be the same as a[&quot;1&quot;]. <br>
                 </p>
-                <h2><a id="predefined-variables"></a>Predefined Variables</h2>
-                <p>These predefined variables have fixed values. Attempting to assign them a value generates an error.</p>
+                <h2><a id="constants"></a>Constants</h2>
+              <p>Some variable names are reserved to hold specific, constant values. In general, constants are written in upper-case, with words separated by underscores, but the most common constants exist in both upper- and lower-case forms. The constants are:</p>
                 <ul>
-                    <li><span class="item-intro">inf:</span> infinity (for negative infinity, prefix this with a minus sign)</li>
-                    <li><span class="item-intro">true:</span> <span class="code">1.0</span></li>
-                    <li> <span class="item-intro">false:</span><span class="code"> 0.0</span></li>
-                    <li> <span class="item-intro">defFrame:</span><span class="code">[frame [observer]]</span> (i.e. the rest frame)</li>
-                    <li><span class="item-intro">null:</span> A special value that represents having no value. For example, if two lines fail to intersect, the result is the null value rather than a coordinate.</li>
+                  <li><span class="literal">NULL</span> or <span class="literal">null</span> — A special value that means the absence of a value.</li>
+                  <li><span class="literal">TRUE</span> or <span class="literal">true</span> — 1.0.</li>
+                  <li><span class="literal">FALSE</span> or <span class="literal">false</span> — 0.0</li>
+                  <li><span class="literal">INF</span> or <span class="literal">inf</span> — positive infinity (for negative infinity, use <span class="literal">-INF</span> or <span class="literal">-inf</span>).</li>
+                  <li><span class="literal">PI</span> — The value of pi.</li>
+                  <li><span class="literal">E</span> —The base of the natural logarithms.</li>
                 </ul>
                 <h1><a id="operators"></a>Operators</h1>
                 <p>Operators operate on one or two values to create a new value. The types of values supported depends on the operators.</p>
@@ -579,10 +580,6 @@
                             <td>Returns the hyperbolic cosine of the value.</td>
                         </tr>
                         <tr>
-                            <td>e(  )</td>
-                            <td>Returns Euler's number <em>e</em>.</td>
-                        </tr>
-                        <tr>
                             <td>exp( <span class="non-terminal">float</span> )</td>
                             <td>Returns Euler's number <em>e</em> raised to the power.</td>
                         </tr>
@@ -605,10 +602,6 @@
                         <tr>
                             <td>min( <span class="non-terminal">float</span> , <span class="non-terminal">float</span> )</td>
                             <td>Returns the smaller of two values.</td>
-                        </tr>
-                        <tr>
-                            <td>pi(  ) </td>
-                            <td>Returns <em>pi</em>.</td>
                         </tr>
                         <tr>
                             <td>random(  )</td>

--- a/src/main/java/org/freixas/gamma/execution/HCodeEngine.java
+++ b/src/main/java/org/freixas/gamma/execution/HCodeEngine.java
@@ -104,34 +104,6 @@ public class HCodeEngine
         setPrecision(SetStatement.PrecisionType.DISPLAY);
     }
 
-    private void initializeSymbolTable(SymbolTable table)
-    {
-        // Add pre-defined variables
-
-        // Infinity values
-
-        table.put("inf", Double.POSITIVE_INFINITY);
-        table.protect("inf");
-
-        // Null
-
-        table.put("null", null);
-        table.protect("null");
-
-        // Add booleans
-
-        table.put("true", 1.0);
-        table.put("false", 0.0);
-
-        table.protect("true");
-        table.protect("false");
-
-        // Add the default frame
-
-        table.put("defFrame", new Frame(defFrame));
-        table.protect("defFrame");
-    }
-
     public MainWindow getMainWindow()
     {
         return window;
@@ -231,7 +203,6 @@ public class HCodeEngine
         }
 
         table = new SymbolTable(this);
-        initializeSymbolTable(table);
 
         LinkedList<Object> code = program.initialize();
         programCounter = 0;

--- a/src/main/java/org/freixas/gamma/execution/SymbolTable.java
+++ b/src/main/java/org/freixas/gamma/execution/SymbolTable.java
@@ -41,16 +41,11 @@ import java.util.ArrayList;
  * we try to create one and it exists in the dynamic symbol table, we check this
  * table. If we find it here, we have an error. If we don't find it in either,
  * them we add it to both. We never use the value stored here.
- * <p>
- * This symbol table supports protected symbols, symbols whose values cannot be
- * changed and which cannot be removed.
  *
  * @author Antonio Freixas
  */
 public class SymbolTable extends BaseSymbolTable
 {
-    private final ArrayList<String> protectedSymbols;
-
     private final StaticSymbolTable staticSymbolTable;
     private final DynamicSymbolTable dynamicSymbolTable;
 
@@ -68,8 +63,6 @@ public class SymbolTable extends BaseSymbolTable
     public SymbolTable(HCodeEngine engine)
     {
         super(engine);
-        this.protectedSymbols = new ArrayList<>();
-
         this.staticSymbolTable = engine.getStaticSymbolTable();
         this.dynamicSymbolTable = engine.getDynamicSymbolTable();
     }
@@ -186,22 +179,9 @@ public class SymbolTable extends BaseSymbolTable
      */
     public void remove(String name)
     {
-        if (protectedSymbols.contains(name)) {
-            throw new ProgrammingException("SymbolTable.remove(): Trying to remove protected symbol '" + name + "'");
-        }
         staticSymbolTable.remove(name);
         dynamicSymbolTable.remove(name);
         super.remove(name);
     }
 
-    /**
-     * Set a variable so it cannot be assigned to. The variable must be added
-     * to the symbol table before making it protected, of course.
-     *
-     * @param symbol The variable to protect.
-     */
-    public void protect(String symbol)
-    {
-        protectedSymbols.add(symbol);
-    }
 }

--- a/src/main/java/org/freixas/gamma/execution/hcode/Function.java
+++ b/src/main/java/org/freixas/gamma/execution/hcode/Function.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
  *
  * @author Antonio Freixas
  */
+@SuppressWarnings("StaticInitializerReferencesSubClass")
 public abstract class Function extends ExecutorContext
 {
     public enum Type
@@ -408,9 +409,9 @@ public abstract class Function extends ExecutorContext
         functions.put("vToTau",     new GenericFunction(Type.VTOTAU));
         functions.put("vToX",       new GenericFunction(Type.VTOX));
 
-        functions.put("gammaToV",          new GenericFunction(Type.GAMMATOV));
+        functions.put("gammaToV",   new GenericFunction(Type.GAMMATOV));
 
-        functions.put("toRelativeAngle",   new toRelativeAngleFunction());
+        functions.put("toRelativeAngle",    new toRelativeAngleFunction());
 
         functions.put("setBounds",          new GenericFunction(Type.SET_BOUNDS));
         functions.put("clearBounds",        new GenericFunction(Type.CLEAR_BOUNDS));
@@ -431,14 +432,12 @@ public abstract class Function extends ExecutorContext
         functions.put("ceil",	    new GenericFunction(Type.CEIL));
         functions.put("cos",	    new GenericFunction(Type.COS));
         functions.put("cosh",       new GenericFunction(Type.COSH));
-        functions.put("e",	        new GenericFunction(Type.E));
         functions.put("exp",	    new GenericFunction(Type.EXP));
         functions.put("floor",	    new GenericFunction(Type.FLOOR));
         functions.put("log",	    new GenericFunction(Type.LOG));
         functions.put("log10",	    new GenericFunction(Type.LOG10));
         functions.put("max",	    new GenericFunction(Type.MAX));
         functions.put("min",	    new GenericFunction(Type.MIN));
-        functions.put("pi",	        new GenericFunction(Type.PI));
         functions.put("random",	    new GenericFunction(Type.RANDOM));
         functions.put("round",	    new GenericFunction(Type.ROUND));
         functions.put("sign",	    new GenericFunction(Type.SIGN));

--- a/src/main/java/org/freixas/gamma/parser/Constants.java
+++ b/src/main/java/org/freixas/gamma/parser/Constants.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Antonio Freixas
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.freixas.gamma.parser;
+
+import java.util.HashMap;
+
+/**
+ * This class controls pre-defined script constants.
+ */
+public class Constants
+{
+    static HashMap<String, Object>map;
+
+    static {
+        map = new HashMap<>();
+        map.put("INF", Double.POSITIVE_INFINITY);
+        map.put("inf", Double.POSITIVE_INFINITY);
+        map.put("NULL", null);
+        map.put("null", null);
+        map.put("TRUE", 1.0);
+        map.put("FALSE", 0.0);
+        map.put("true", 1.0);
+        map.put("false", 0.0);
+        map.put("PI", Math.PI);
+        map.put("E", Math.E);
+    }
+
+    /**
+     * Returns true if the given name represents a script constant.
+     *
+     * @param name The name to check.
+     *
+     * @return True if the given name represents a script constant.
+     */
+    static public boolean isConstant(String name)
+    {
+        return map.containsKey(name);
+    }
+
+    /**
+     * Returns the value of a constant with a given name. Since the names
+     * "NULL" and "null" return null as their values, this method cannot be
+     * used to determine if a particular name represents a constant.
+     *
+     * @param name The name of the constant whose value we want.
+     *
+     * @return The value of the constant (may be null).
+     */
+    static public Object get(String name)
+    {
+        return map.get(name);
+    }
+}


### PR DESCRIPTION
Fixes #6. 
Constants are now in upper-case although some have lower-case equivalents.
Constants are now processed by the parser and not added to the symbol table.
Protected symbol table entries are no longer needed.