### PR TITLE
Fix arrowheads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
 
     <!-- *** VERSION *** -->
 
-    <version>1.0.3</version>
+    <!-- Increment this after a release -->
+    <version>1.0.4</version>
 
     <developers>
         <developer>
@@ -27,7 +28,8 @@
     <properties>
         <gamma.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</gamma.version>
         <gamma.fullversion>${project.version}</gamma.fullversion>
-        <gamma.release.tag>v${project.version}-RC2</gamma.release.tag>
+        <!-- Reset to -RC1 after a release and increment it if testing on the release candidate fails -->
+        <gamma.release.tag>v${project.version}-RC1</gamma.release.tag>
         <gamma.java.version>25</gamma.java.version>
         <gamma.maven.version>3.9.11</gamma.maven.version>
         <gamma.git.version>2.51.1</gamma.git.version>

--- a/src/main/java/org/freixas/gamma/math/Util.java
+++ b/src/main/java/org/freixas/gamma/math/Util.java
@@ -133,7 +133,9 @@ public final class Util
 
     /**
      * Get the angle of a line segment (from +180 to -180). The line segment
-     * could potentially have infinite endpoints.
+     * could potentially have infinite endpoints. The angle should be dependent
+     * on the order of the endpoints. (0, 0) to (-10, -10) is -45 degrees, but
+     * (10, 10) to (0, 0) is 135 degrees.
      * <p>
      * Java’s Math.atan2() already copes with most infinities, but there are a
      * few edge cases:
@@ -180,11 +182,7 @@ public final class Util
 
         // Fall back to atan2 which handles infinities correctly
 
-        double angle = Math.toDegrees(Math.atan2(deltaT, deltaX));
-
-        if (deltaX > 0.0) return angle;
-        if (angle <= 0.0) return 180.0 + angle;
-        return angle - 180.0;
+        return Math.toDegrees(Math.atan2(deltaT, deltaX));
     }
 
     static public double asinh(double x)


### PR DESCRIPTION
Fixes #44: The angle calculated for line segments didn't pay attention to the direction of the segment. This caused arrowheads to be drawn incorrectly.