### PR TITLE
Fix missing arrowhead features

### DIFF
--- a/.github/workflows/maven-build-installer-all.yml
+++ b/.github/workflows/maven-build-installer-all.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: refs/tags/v1.0.3-RC2
+          ref: refs/tags/v1.0.4-RC1
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5
@@ -46,7 +46,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gamma-1.0.3-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.type }}
+          name: gamma-1.0.4-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.type }}
           path: ./target/*.${{ matrix.type }}
           if-no-files-found: error
 

--- a/.github/workflows/maven-build-installer-macos.yml
+++ b/.github/workflows/maven-build-installer-macos.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: refs/tags/v1.0.3-RC2
+          ref: refs/tags/v1.0.4-RC1
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/maven-build-installer-unix.yml
+++ b/.github/workflows/maven-build-installer-unix.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        ref: refs/tags/v1.0.3-RC2
+        ref: refs/tags/v1.0.4-RC1
     - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ scripts (Gamma programs) under **Help / Sample Scripts**.
 
 ## Download and install
 
-- An [MSI installer](https://github.com/freixas/gamma/releases/download/v1.0.3/gamma-1.0.3.msi) for x64-based Windows 11 systems (likely to work on x64 Windows 7-10).
-- A [DEB package](https://github.com/freixas/gamma/releases/download/v1.0.3/gamma-1.0.3-ubuntu-22.04-x64.deb) for x64 Debian-based Linux distributions
-- A [DEB package](https://github.com/freixas/gamma/releases/download/v1.0.3/gamma-1.0.3-ubuntu-24.04-x64.deb) for x64 Debian-based Linux distributions
-- A [DMG package](https://github.com/freixas/gamma/releases/download/v1.0.3/gamma-1.0.3-macos-14-arm64.dmg) for arm64-based macOS 14 systems
-- A [DMG package](https://github.com/freixas/gamma/releases/download/v1.0.3/gamma-1.0.3-macos-15-arm64.dmg) for arm64-based macOS 15 systems
+- An [MSI installer](https://github.com/freixas/gamma/releases/download/v1.0.4/gamma-1.0.4.msi) for x64-based Windows 11 systems (likely to work on x64 Windows 7-10).
+- A [DEB package](https://github.com/freixas/gamma/releases/download/v1.0.4/gamma-1.0.4-ubuntu-22.04-x64.deb) for x64 Debian-based Linux distributions
+- A [DEB package](https://github.com/freixas/gamma/releases/download/v1.0.4/gamma-1.0.4-ubuntu-24.04-x64.deb) for x64 Debian-based Linux distributions
+- A [DMG package](https://github.com/freixas/gamma/releases/download/v1.0.4/gamma-1.0.4-macos-14-arm64.dmg) for arm64-based macOS 14 systems
+- A [DMG package](https://github.com/freixas/gamma/releases/download/v1.0.4/gamma-1.0.4-macos-15-arm64.dmg) for arm64-based macOS 15 systems
 
-There is also a universal [tar.gz file](https://github.com/freixas/gamma/releases/download/v1.0.3/gamma-1.0.3.tar.gz) 
+There is also a universal [tar.gz file](https://github.com/freixas/gamma/releases/download/v1.0.4/gamma-1.0.4.tar.gz) 
 which should work on any system with Java and JavaFX.
 
 Currently, the Windows installer has received the most testing, the Unix installers have received some,
@@ -159,8 +159,8 @@ but I used versions from:
 
 <details><summary>Install Gamma</summary>
 
-Download gamma-1.0.3.tar.gz from the GitHub release page. Extract the included
-gamma-1.0.3 folder to any location. If you unpacked the file into <some path>, 
+Download gamma-1.0.4.tar.gz from the GitHub release page. Extract the included
+gamma-1.0.4 folder to any location. If you unpacked the file into <some path>, 
 then add `<some path>` to your PATH.
 
 At the top level of the Gamma folder, you will find two files:

--- a/src/main/help/editing.html
+++ b/src/main/help/editing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
 <meta charset="utf-8" />

--- a/src/main/help/expressions.html
+++ b/src/main/help/expressions.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />
@@ -56,7 +56,7 @@
                 <p>A <span class="definition">literal</span> is an entity whose value is expressed in the characters that represent it. For example, <span class="code">24</span> is the literal representation of the value 24, <span class="code">&quot;abc&quot;</span> is the literal representation of the character string 123, and <span class="code">[observer velocity 0.5]</span> is the literal representation of an observer with a specific worldline.</p>
                 <p>Literal values are covered in the section on <a href="values.html">values</a>.</p>
                 <h1><a id="variables"></a>Variables</h1>
-                <p>Variables are named entities that can be thought of as an address to a value. A value can be stored or fetched using the variable's name. Variables receive values through <a href="statements.html#assignment-statements">assignment statements</a> and they can be used in expressions anywhere that a literal is allowed.</p>
+                <p>Variables are named entities that can be thought of as an address to a value. A value can be stored or fetched using the variable's name. Variables receive values through <a href="statements.html#assignment-statements">assignment statements</a>, and they can be used in expressions anywhere that a literal is allowed.</p>
                 <p>A variable starts with an alphabetic character. This character can be followed by any number of letters, digits, or underscores.</p>
                 <p>Variables are created when they are first assigned a value. The type of variable is the same as the type of the value assigned to it. This type could change in a future assignment.</p>
                 <h2><a id="static-variables"></a>Static Variables</h2>
@@ -324,7 +324,7 @@
                     <tbody>
                         <tr>
                             <td>gamma( <span class="non-terminal">frame</span> )</td>
-                            <td>The gamma value for the given frame. The <span class="non-terminal">frame</span> arguement can also be a <span class="non-terminal">float</span> (velocity) or <span class="non-terminal">observer</span>.</td>
+                            <td>The gamma value for the given frame. The <span class="non-terminal">frame</span> argument can also be a <span class="non-terminal">float</span> (velocity) or <span class="non-terminal">observer</span>.</td>
                         </tr>
                         <tr>
                             <td>gammaToV( <span class="non-terminal">float</span> )</td>
@@ -332,11 +332,11 @@
                         </tr>
                         <tr>
                           <td>lengthContraction( float , frame )</td>
-                          <td>The first value is a length as measured in the frame given as the second argument. The <span class="non-terminal">frame</span> arguement can also be a <span class="non-terminal">float</span> (velocity) or <span class="non-terminal">observer</span>. The result is the contracted length measured in the rest frame.</td>
+                          <td>The first value is a length as measured in the frame given as the second argument. The <span class="non-terminal">frame</span> argument can also be a <span class="non-terminal">float</span> (velocity) or <span class="non-terminal">observer</span>. The result is the contracted length measured in the rest frame.</td>
                         </tr>
                         <tr>
                           <td>timeDilation( float , frame )</td>
-                          <td>The first value is a duration as measured in the frame given as the second argument. The <span class="non-terminal">frame</span> arguement can also be a <span class="non-terminal">float</span> (velocity) or <span class="non-terminal">observer</span>. The result is the dilated duration measured in the rest frame.</td>
+                          <td>The first value is a duration as measured in the frame given as the second argument. The <span class="non-terminal">frame</span> argument can also be a <span class="non-terminal">float</span> (velocity) or <span class="non-terminal">observer</span>. The result is the dilated duration measured in the rest frame.</td>
                         </tr>
                         <tr>
                           <td>toRelativeV( float , frame (, frame)* )</td>

--- a/src/main/help/index.html
+++ b/src/main/help/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/menu.html
+++ b/src/main/help/menu.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/quick-start.html
+++ b/src/main/help/quick-start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/shortcuts.html
+++ b/src/main/help/shortcuts.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/slideshows.html
+++ b/src/main/help/slideshows.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />
@@ -44,7 +44,7 @@
                 <p><span class="non-terminal">scriptStatement</span> → <span class="literal">script</span> string <span class="non-terminal">scriptSettings</span>?<br>
                   <span class="non-terminal">scriptSettings</span> → <span class="literal">pause</span> <span class="non-terminal">float</span><br>
                 </p>
-                <p>The <span class="literal">script</span> statement is folowed by a literal string that refers to a script file. If the file name is relative, it is relative to the location of the slideshow script. If a slideshow  is located on the web, all scripts must come from the same domain. If the slideshow is on the local file system, each script can come from anywhere.</p>
+                <p>The <span class="literal">script</span> statement is followed by a literal string that refers to a script file. If the file name is relative, it is relative to the location of the slideshow script. If a slideshow  is located on the web, all scripts must come from the same domain. If the slideshow is on the local file system, each script can come from anywhere.</p>
                 <p>The optional <span class="literal">pause</span> controls the number of seconds to pause after a slide finishes. Unlike  <span class="literal">defaultPause</span>, it applies to any kind of script. The pause time begins after the diagram is drawn or after the last frame of an animated diagram is drawn. Once the pause timer starts, it will be reset to its full pause time by any user interaction—zooming, panning, manipulating a GUI control, or changing the animation frame.</p>
                 <p>If a script within a slideshow is itself a script, it will be incorporated as though the individual scripts it contains had been entered in its place. The only difference is that the default pause times for scripts without explicit pause times will come from the nested slideshow rather than the top-level one.</p>
             </div>

--- a/src/main/help/statements.html
+++ b/src/main/help/statements.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />
@@ -102,7 +102,7 @@
                 <p>An include statement includes the text from another file into this one. The effect is as though those characters had been entered in place of the include statement.</p>
                 <p>The string is a filename. It can be a relative filename, in which case it's relative to the script file's location, or it can be an absolute filename.</p>
                 <h2><a id="stylesheet"></a>stylesheet</h2>
-                <p><span class="literal">stylesheet external</span>l* <span class="non-terminal">string</span></p>
+                <p><span class="literal">stylesheet external</span>* <span class="non-terminal">string</span></p>
                 <p>The stylesheet statement adds a stylesheet to the diagram (see <a href="stylesheets.html">Stylesheets</a>). If <span class="literal">external</span> is used, the stylesheet comes from a file and the string is the file's name.  It can be a relative filename, in which case it's relative to the script file's location, or it can be an absolute filename.</p>
                 <p>If <span class="literal">external</span> is omitted, the entire stylesheet must be contained in the string. Since stylesheets can have values that are strings, you will need to be careful with how the internal strings are specified.</p>
                 <h2><a id="set"></a>set</h2>
@@ -155,7 +155,7 @@
                 <p>The final string is a label displayed with the slider.</p>
                 <h2><a id="toggle"></a>toggle</h2>
                 <p><span class="literal">toggle</span> <span class="non-terminal">leftVariable</span> <span class="literal">=</span><span class="non-terminal"> float</span> <span class="literal">label</span> <span class="non-terminal">string</span> <span class="literal">restart</span>? </p>
-                <p>A toogle  assignment adds a checkbox to the diagram. If the value given is not zero, the variable is set to 1, otherwise it is set to 0.</p>
+                <p>A toggle assignment adds a checkbox to the diagram. If the value given is not zero, the variable is set to 1, otherwise it is set to 0.</p>
                 <p>The diagram is created by executing the script with the variable set to its assigned value. If the end user toggles the checkbox, the script is re-executed. This time, the assignment is ignored and the value of the variable is set to match the slider.</p>
                 <p>Initially, the checkbox is checked if the given value is not zero, unchecked if it is 0. When the end user toggles it, the variable will be set to either 0 or 1, depending on whether the box is unchecked or checked.</p>
                 <p>The final string is a label displayed with the toggle.</p>
@@ -187,7 +187,7 @@
                 <p class="literal">continue</p>
                 <p>The continue statement returns an enclosing while or for statement to return to its conditional test. In the case of the for statement, the loop variable is incremented (or decremented if the step value is negative) before testing. A continue statement outside any loop generates an error.</p>
                 <h1><a id="command-statements"></a>Command Statements</h1>
-                <p>Command statements are things that either control how the diagram is drawn or draw something on the diagram. The have a common syntax:</p>
+                <p>Command statements are things that either control how the diagram is drawn or draw something on the diagram. They have a common syntax:</p>
                 <p><span class="non-terminal">command</span> ( <span class="non-terminal">name</span> <span class="literal">:</span> <span class="non-terminal">expr</span> ( <span class="literal">,</span> <span class="non-terminal">name</span> <span class="literal">:</span> <span class="non-terminal">expr</span> )* )?</p>
                 <p>The name/expression pairs are called properties and the sequence of properties is a property list. Each command has a set of properties that control how it behaves. Almost all properties are optional and have a default value if omitted. The specific properties supported by each command are defined below.</p>
                 <p>For some commands, there is one property that is either required or very common. This property is given without the property name or colon. In the tables below, these special properties are identified by a color: a <span class="red-literal">red</span> property is required and a <span class="green-literal">green</span> property is optional.</p>
@@ -940,7 +940,7 @@
 
                             </td>
                             <td class="description">
-                                Draw the lines parallel to the <span class="non-terminal">x</span> axis.
+                                Draw the lines parallel to the <span class="non-terminal">x</span>-axis.
                             </td>
                         </tr>
                         <tr>
@@ -960,7 +960,7 @@
 
                             </td>
                             <td class="description">
-                                Draw the lines parallel to the <span class="non-terminal">t</span> axis.
+                                Draw the lines parallel to the <span class="non-terminal">t</span>-axis.
                             </td>
                         </tr>
                     </tbody>

--- a/src/main/help/status-line.html
+++ b/src/main/help/status-line.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/stylesheets.html
+++ b/src/main/help/stylesheets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />
@@ -61,15 +61,15 @@
                 <p>( <span class="non-terminal">selector</span> ( <span class="literal">,</span> <span class="non-terminal">selector</span> )* )? { ( <span class="non-terminal">styleProperty</span>? <span class="literal">;</span> )?* }</p>
                 <p>A rule consists of zero or more <span class="definition">selectors</span>, separated by commas, followed by a set of zero or more style properties enclosed within braces, with each style property ending with a semicolon.</p>
                 <p>The shorthand </p>
-                <p class="code">selector1, selector2 { ... some style properties .. }</p>
+                <p class="code">selector1, selector2 { ... some style properties ... }</p>
                 <p>is exactly equivalent to </p>
-                <p class="code">selector1 { ... some style properties .. }</p>
+                <p class="code">selector1 { ... some style properties ... }</p>
                 <p class="code">selector2 { ... the same style properties ... }</p>
                 <h1><a id="selectors"></a>Selectors</h1>
                 <p>Selectors are used to select which style properties are applied to a given command. </p>
                 <p>There are three things used to match a selector to a command: the command name, the command's id value and one or more of the classes listed in the command's class value. Let's look at an example:</p>
                 <p class="code">axes id: &quot;id1&quot;, class: &quot;class1, class2&quot;;</p>
-                <p>The three elements here are: the name &quot;axes&quot;, the id &quot;id1&quot; and the two classes &quot;class1&quot; and &quot;class2&quot; (which are separated by commas). When used in a selector, the id value is prefixed with a &quot;#&quot; and each classname is prefixed with a &quot;.&quot;. The elements desired for a match are then concatenated together. The following selectors would all match the command above:</p>
+                <p>The three elements here are: the name &quot;axes&quot;, the id &quot;id1&quot; and the two classes &quot;class1&quot; and &quot;class2&quot; (which are separated by commas). When used in a selector, the id value is prefixed with a &quot;#&quot; and each class name is prefixed with a &quot;.&quot;. The elements desired for a match are then concatenated together. The following selectors would all match the command above:</p>
                 <ul>
                     <li>axes, </li>
                     <li>#id1</li>
@@ -98,7 +98,7 @@
                         <col class="column6" />
                     </colgroup>
                     <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -108,7 +108,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style">#000000</td>
@@ -116,7 +116,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for axes, grids, hypergrids, lines, paths, worldlines, event shapes, event boost lines, and text.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">x-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">color</span><span class="char-style-override-3"></span></td>
@@ -124,7 +124,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for the x-axis, x grid lines, and x hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">t-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">color</span><span class="char-style-override-3"></span></td>
@@ -132,7 +132,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for the t axis, t grid lines, and t hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">div-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">color</span><span class="char-style-override-3"></span></td>
@@ -140,7 +140,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for tick marks, grid lines, and hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-div-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">div-color</span></td>
@@ -148,7 +148,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for x tick marks, x grid lines, and x hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">t-div-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">div-color</span><span class="char-style-override-3"></span></td>
@@ -156,7 +156,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for t tick marks, t grid lines, and t hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">major-div-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">div-color</span><span class="char-style-override-3"></span></td>
@@ -164,7 +164,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for major tick marks, and major grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">x-major-div–color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">major-div–color</span></td>
@@ -172,7 +172,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for major x tick marks, and major x grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">t-major-div–color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">major-div–color</span><span class="char-style-override-3"></span></td>
@@ -180,7 +180,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for major t tick marks, and major t grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">text-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">color</span><span class="char-style-override-3"></span></td>
@@ -188,7 +188,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for all text.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">x-text-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">text-color</span></td>
@@ -196,7 +196,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for x tick marks.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">t-text-color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style"><span class="literal">text-color</span></td>
@@ -204,7 +204,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for t tick marks.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">background–color</span></td>
                             <td class="body-style"><span class="non-terminal">color</span></td>
                             <td class="body-style">#FFFFFF</td>
@@ -225,7 +225,7 @@
                         <col class="column6" />
                     </colgroup>
                    <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -235,7 +235,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">1.0</td>
@@ -243,7 +243,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for axes, tick marks, grids, hypergrids, lines, worldlines, and event boost lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">x-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">line-thickness</span><span class="char-style-override-3"></span></td>
@@ -251,7 +251,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for x axes, x tick marks, x grid lines, and x hypergrids lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">t-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">line-thickness</span><span class="char-style-override-3"></span></td>
@@ -259,7 +259,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for t axes, t tick marks, t grid lines, and t hypergrids lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">div-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">line-thickness</span><span class="char-style-override-3"></span></td>
@@ -267,7 +267,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for tick marks, x grid lines, and x hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-div-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">div-line-thickness</span></td>
@@ -275,7 +275,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for x tick marks, x grid lines, and x hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">t-div-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">div-line-thickness</span></td>
@@ -283,7 +283,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for t tick marks, t grid lines, and t hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">major-div-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">div-line-thickness</span></td>
@@ -291,7 +291,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for major tick marks, and major grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">x-major-div-line-thickness</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">major-div-line-thickness</span><span class="char-style-override-4"></span></td>
@@ -299,7 +299,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line thickness for major x tick marks, and major x grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">t-major-div-line-thickness</span><span class="Literal char-style-override-5"></span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">major-div-line-thickness</span><span class="char-style-override-4"></span></td>
@@ -307,7 +307,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The color for major t tick marks, and major t grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-9">
+                        <tr>
                             <td class="body-style"><span class="literal">line-style</span></td>
                             <td class="body-style"><span class="Table-Contents"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></span></td>
                             <td class="body-style"><span class="literal">solid</span></td>
@@ -315,7 +315,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for axes, tick marks, grids, hypergrids, lines, worldlines, and event boost lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">line-style</span><span class="char-style-override-3"></span></td>
@@ -323,7 +323,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for x axes, x tick marks, x grid lines, and x hypergrids lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">t-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">line-style</span><span class="char-style-override-3"></span></td>
@@ -331,7 +331,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for t axes, t tick marks, t grid lines, and t hypergrids lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">div-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">line-style</span><span class="char-style-override-3"></span></td>
@@ -339,7 +339,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for tick marks, x grid lines, and x hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">x-div-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">div-line-style</span></td>
@@ -347,7 +347,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for x tick marks, x grid lines, and x hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">t-div-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">div-line-style</span></td>
@@ -355,7 +355,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for t tick marks, t grid lines, and t hypergrid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">major-div-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">div-line-style</span></td>
@@ -363,7 +363,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for major tick marks, and major grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-major-div-line-style</span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">major-div-line-style</span><span class="char-style-override-4"></span></td>
@@ -371,7 +371,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The line style for major x tick marks, and major x grid lines.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">t-major-div-line-style</span><span class="Literal char-style-override-5"></span></td>
                             <td class="body-style"><span class="literal">solid</span>, <span class="literal">dashed, dotted</span></td>
                             <td class="body-style"><span class="literal">major-div-line-style</span><span class="char-style-override-4"></span></td>
@@ -392,7 +392,7 @@
                         <col class="column6" />
                     </colgroup>
                     <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -402,7 +402,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">font-family</span></td>
                             <td class="body-style"><span class="non-terminal">string</span></td>
                             <td class="body-style"><p class="Table-Contents">System <br />
@@ -411,7 +411,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font family for any text.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">tick-font-family</span></td>
                             <td class="body-style"><span class="non-terminal">string</span></td>
                             <td class="body-style"><span class="literal">font-family</span></td>
@@ -419,7 +419,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font family for tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-tick-font-family</span></td>
                             <td class="body-style"><span class="non-terminal">string</span></td>
                             <td class="body-style"><span class="literal">tick-font-family</span></td>
@@ -427,7 +427,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font family for x tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">t-tick-font-family</span></td>
                             <td class="body-style"><span class="non-terminal">string</span></td>
                             <td class="body-style"><span class="literal">tick-font-family</span></td>
@@ -435,7 +435,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font family for t tick label.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">font-weight</span></td>
                             <td class="body-style"><span class="literal">normal</span>, others<span class="footnote">1</span></td>
                             <td class="body-style"><span class="literal">normal</span></td>
@@ -443,7 +443,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font weight for any text.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">tick-font-weight</span></td>
                             <td class="body-style"><span class="literal">normal</span>, others<span class="footnote">1</span></td>
                             <td class="body-style"><span class="literal">font-weight</span></td>
@@ -451,7 +451,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font weight for tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-tick-font-weight</span></td>
                             <td class="body-style"><span class="literal">normal</span>, others<span class="footnote">1</span></td>
                             <td class="body-style"><span class="literal">tick-font-weight</span></td>
@@ -459,7 +459,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font weight x tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">x-tick-font-weight</span></td>
                             <td class="body-style"><span class="literal">normal</span>, others<span class="footnote">1</span></td>
                             <td class="body-style"><span class="literal">tick-font-weight</span></td>
@@ -467,7 +467,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font weight t tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">font-style</span></td>
                             <td class="body-style"><span class="literal">regular</span>, <span class="literal">italic</span></td>
                             <td class="body-style"><span class="literal">regular</span></td>
@@ -475,7 +475,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font style for any text.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">tick-font-style</span></td>
                             <td class="body-style"><span class="literal">regular</span>, <span class="literal">italic</span></td>
                             <td class="body-style"><span class="literal">font-style</span></td>
@@ -483,7 +483,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font style for tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">x-tick-font-style</span></td>
                             <td class="body-style"><span class="literal">regular</span>, <span class="literal">italic</span></td>
                             <td class="body-style"><span class="literal">tick-font-style</span></td>
@@ -491,7 +491,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font style for x tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">t-tick-font-style</span></td>
                             <td class="body-style"><span class="literal">regular</span>, <span class="literal">italic</span></td>
                             <td class="body-style"><span class="literal">tick-font-style</span></td>
@@ -499,7 +499,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font style for t tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">font-size</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">10.0</td>
@@ -507,7 +507,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font size for any text. This is the height of the text from ascender to descender. (text)</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">tick-font-size</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">font-size</span><span class="Symbolic-Reference char-style-override-7"></span></td>
@@ -515,7 +515,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font size for tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">x-tick-font-size</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">tick-font-size</span></td>
@@ -523,7 +523,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the font size for x tick labels.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">t-tick-font-size</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">tick-font-size</span></td>
@@ -545,7 +545,7 @@
                         <col class="column6" />
                     </colgroup>
                     <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -555,7 +555,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-10">
+                        <tr>
                             <td class="body-style"><span class="literal">text-padding</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">2.0</td>
@@ -563,7 +563,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the text padding. Find the bounding box of the text (from left to right and from the highest ascender to the lowest descender) and pad each side of the box with the given number of transparent pixels. (Note: may be changed to padding.)</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">text-padding-top</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">text-padding</span><span class="char-style-override-3"></span></td>
@@ -571,7 +571,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the top text padding. (Note: may be changed to padding-top.)</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">text-padding–bottom</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">text-padding</span><span class="char-style-override-3"></span></td>
@@ -579,7 +579,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the bottom text padding. (Note: may be changed to padding-bottom.)</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">text-padding-left</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">text-padding</span><span class="char-style-override-3"></span></td>
@@ -587,7 +587,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the top left padding. (Note: may be changed to padding-left.)</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">text-padding-right</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style"><span class="literal">text-padding</span><span class="char-style-override-3"></span></td>
@@ -595,7 +595,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the top right padding. (Note: may be changed to padding-right.)</td>
                         </tr>
-                        <tr class="Row-Column-11">
+                        <tr>
                             <td class="body-style"><span class="literal">text-anchor</span></td>
                             <td class="body-style"><span class="literal">TL</span>, <span class="literal">TC</span>, <span class="literal">TR</span>,
                                 <span class="literal">ML</span>, <span class="literal">MC</span>, <span class="literal">MR</span>,
@@ -618,7 +618,7 @@
                         <col class="column6" />
                     </colgroup>
                     <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -628,7 +628,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">ticks</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">true</span></td>
@@ -636,7 +636,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Draw the tick marks.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">x-ticks</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">ticks</span><span class="char-style-override-3"></span></td>
@@ -644,7 +644,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Draw the x tick marks.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">t-ticks</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">ticks</span><span class="char-style-override-3"></span></td>
@@ -652,7 +652,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Draw the t tick marks.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">tick-labels</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style">true</td>
@@ -660,7 +660,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Label the tick marks (only if drawn).</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">x-tick-labels</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">tick-labels</span></td>
@@ -668,7 +668,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Label the x tick marks (only if drawn).</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">t-tick-labels</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">tick-labels</span></td>
@@ -676,7 +676,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Label the t tick marks (only if drawn).</td>
                         </tr>
-                        <tr class="Row-Column-6">
+                        <tr>
                             <td class="body-style"><span class="literal">tick-length</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">3.0</td>
@@ -684,7 +684,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">The length of the tick marks. The actual length is this length + the axis line thickness.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">major-tick-length</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">10.0</td>
@@ -705,7 +705,7 @@
                         <col class="column6" />
                     </colgroup>
                    <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -715,7 +715,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">left-quadrant</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">true</span></td>
@@ -723,7 +723,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Draw the hypergrid in the left quadrant.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">right-quadrant</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">true</span><span class="char-style-override-3"></span></td>
@@ -731,7 +731,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Draw the hypergrid in the right quadrant.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">top-quadrant</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">true</span><span class="char-style-override-3"></span></td>
@@ -739,7 +739,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Draw the hypergrid in the top quadrant.</td>
                         </tr>
-                        <tr class="Row-Column-7">
+                        <tr>
                             <td class="body-style"><span class="literal">bottom-quadrant</span></td>
                             <td class="body-style"><span class="non-terminal">boolean</span></td>
                             <td class="body-style"><span class="literal">true</span><span class="char-style-override-3"></span></td>
@@ -760,7 +760,7 @@
                         <col class="column6" />
                     </colgroup>
                     <thead>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="Header-Cell">Name</td>
                             <td class="Header-Cell">Type</td>
                             <td class="Header-Cell">Default</td>
@@ -770,7 +770,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr class="Row-Column-13">
+                        <tr>
                             <td class="body-style"><span class="literal">opacity</span></td>
                             <td class="body-style"><span class="non-terminal">double</span></td>
                             <td class="body-style">1.0</td>
@@ -778,7 +778,7 @@
                             <td class="body-style">1.0</td>
                             <td class="description">Sets the opacity of all elements generated by a command. 0.0 is completely transparent; 1.0 is completely opaque.</td>
                         </tr>
-                        <tr class="Row-Column-14">
+                        <tr>
                             <td class="body-style"><span class="literal">arrow</span></td>
                             <td class="body-style"><span class="literal">none</span>, <span class="literal">both</span>, <span class="literal">start</span>, <span class="literal">end</span></td>
                             <td class="body-style"><span class="literal">none</span></td>
@@ -786,7 +786,18 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Place arrowheads at the start, end, or both of lines. This applies to the explicitly clipped ends of lines or worldlines, to non-closed paths, to axes, and to event boost lines. For most things, the start is the end with the smaller <span class="Coordinates">t</span> coordinate. If the <span class="Coordinates">t</span> coordinates are the same for both ends,  the start is the end with the smaller <span class="Coordinates">x</span> coordinate.  For paths, the start and end are defined by the path.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
+                            <td class="body-style"><span class="literal">arrow-style</span></td>
+                            <td class="body-style"><span class="literal">open</span>, <span class="literal">closed</span>, <span class="literal">filled</span>, <span class="literal">chevron</span></td>
+                            <td class="body-style"><span class="literal">open</span></td>
+                            <td class="body-style">&#160;</td>
+                            <td class="body-style">&#160;</td>
+                            <td class="description">
+                                Sets the style used to draw the arrowheads. Open uses two lines to indicate the arrowhead. Closed closes the two lines into a triangle. Filled fills the triangle.
+                                Chevron draws a filled arrowhead using a chevron shape.
+                            </td>
+                        </tr>
+                        <tr>
                             <td class="body-style"><span class="literal">arrow-width</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">10.0</td>
@@ -794,7 +805,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">If the arrowhead is horizontal, this is its width.</td>
                         </tr>
-                        <tr class="Row-Column-8">
+                        <tr>
                             <td class="body-style"><span class="literal">arrow-height</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">8.0</td>
@@ -802,7 +813,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">If the arrowhead is horizontal, this is its height.</td>
                         </tr>
-                        <tr class="Row-Column-5">
+                        <tr>
                             <td class="body-style"><span class="literal">event-diameter</span></td>
                             <td class="body-style"><span class="non-terminal">float</span></td>
                             <td class="body-style">5.0</td>
@@ -810,7 +821,7 @@
                             <td class="body-style">&#160;</td>
                             <td class="description">Set the diameter of an event shape.</td>
                         </tr>
-                        <tr class="Row-Column-15">
+                        <tr>
                             <td class="body-style"><span class="literal">event-shape</span></td>
                             <td class="body-style"><span class="literal">circle</span><span class="non-terminal">, </span><span class="literal">square</span><span class="non-terminal">, </span><span class="literal">diamond</span><span class="non-terminal">, </span><span class="literal">star</span></td>
                             <td class="body-style"><span class="literal">circle</span></td>
@@ -824,7 +835,7 @@
               <p>There are three ways to name colors: using hexadecimal values, color names, or color functions.</p>
                 <h3><a id="hexadecimal-colors"></a>Hexadecimal Colors</h3>
                 <p>Hexadecimal colors use one byte each (written in hexadecimal) for red, green, blue, and alpha values, for a total of 8 hexadecimal characters. The 8 characters are preceded with a &quot;#&quot;. </p>
-                <p>If there are only three or four characters, each characters is doubled (e.g. &quot;#123&quot; becomes &quot;#112233&quot;). If there are now only six characters, FF is appended (an alpha value that means fully opaque).</p>
+                <p>If there are only three or four characters, each character is doubled (e.g. &quot;#123&quot; becomes &quot;#112233&quot;). If there are now only six characters, FF is appended (an alpha value that means fully opaque).</p>
                 <h3><a id="color-names"></a>Color Names</h3>
                 <p>The following color names may be used wherever a color is required. The corresponding hex value is in parentheses: </p>
                 <table class="colorname-table">

--- a/src/main/help/syntax.html
+++ b/src/main/help/syntax.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/templates/gamma-help.dwt
+++ b/src/main/help/templates/gamma-help.dwt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/help/toolbar.html
+++ b/src/main/help/toolbar.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" href="styles/help.css" type="text/css" />
@@ -52,7 +52,7 @@
                 <p>Creates a file, associates it with the window, load the empty file, and executes the empty script. From then on, each time the file (or any dependent file) is saved, the file will be re-loaded and executed.</p>
                 <h3><a id="open-file"></a><img src="images/open-file.png" width="32" height="32" alt="Open file"></h3>
                 <p>Opens an existing file, associates it with the window, loads the script, and executes it. From then on, each time the file (or any dependent file) is saved, the file will be re-loaded and executed.</p>
-                <h3><a id="open-url"><img src="images/open-url.png" width="32" height="32" alt="Open URL"></a></h3>
+                <h3><a id="open-URL"><img src="images/open-url.png" width="32" height="32" alt="Open URL"></a></h3>
                 <p>Opens an existing file located on the web, associates it with the window, loads the script, and executes it. The file is not monitored for changes.</p>
                 <h3><a id="export-diagram"></a><img src="images/export-diagram.png" width="32" height="32" alt="Export diagram"></h3>
                 <p>Saves the diagram as a JPG, PNG, or TIFF.</p>
@@ -67,7 +67,7 @@
                 <h3><a id="play-pause-mode"><img src="images/ss_play.png" width="32" height="32" alt="Enable play mode"> <img src="images/ss_pause.png" width="32" height="32" alt="Enable pause mode"></a></h3>
                 <p>You can use this button to play or pause the animation (the icon shown is for the mode you will enter, not the mode currently enabled).  In &quot;play&quot; mode, scripts (slides) advance automatically from one to the next; in &quot;pause&quot; mode, scripts (slides) advance only through the use of the slideshow controls.                </p>
                 <p>The point at which the slide advances depends on the slide and the pause time assigned to it. Once a diagram is drawn (for an animation, once the last frame of the animation is drawn), it will remain for some number of seconds before advancing. The delay time is unique to each slide and can range from 0 to infinity (if it is infinity, the slide will never automatically advance).</p>
-                <p>If you interact with the slide, the delay time resets to its full delay time. An interaction can be a zoom or pan action, or moving a GUI control. For example, if the delay time is 5 seconds, a slide will advace (in play mode) only 5 seconds after it is drawn or after your last interaction with it.</p>
+                <p>If you interact with the slide, the delay time resets to its full delay time. An interaction can be a zoom or pan action, or moving a GUI control. For example, if the delay time is 5 seconds, a slide will advance (in play mode) only 5 seconds after it is drawn or after your last interaction with it.</p>
                 <h3><a id="next-slide"><img src="images/ss_next.png" width="32" height="32" alt="Go to the next slide"></a></h3>
                 <p>Go to the next script (slide) in the slideshow.</p>
                 <h3><a id="last-slide"><img src="images/ss_end.png" width="32" height="32" alt="Go to last slide"></a></h3>

--- a/src/main/help/values.html
+++ b/src/main/help/values.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/gamma-help.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="styles/help.css" type="text/css" />

--- a/src/main/java/org/freixas/gamma/css/value/StyleProperties.java
+++ b/src/main/java/org/freixas/gamma/css/value/StyleProperties.java
@@ -123,7 +123,7 @@ public final class StyleProperties
     }
 
     /**
-     * The Arrow types: none, both, start, and end.
+     * The Arrow position types: none, both, start, and end.
      */
     public enum Arrow implements StylePropertyValueEnum
     {
@@ -136,6 +136,22 @@ public final class StyleProperties
         @Override
         public final String getName() { return name; }
         static public Arrow toEnum(String name)  { return map.get(name.toLowerCase()); }
+    }
+
+    /**
+     * The ArrowStyle types: none, both, start, and end.
+     */
+    public enum ArrowStyle implements StylePropertyValueEnum
+    {
+        OPEN("open"), CLOSED("closed"), FILLED("filled"), CHEVRON("chevron");
+
+        static private final HashMap<String, ArrowStyle> map = toMap(ArrowStyle.values());
+        private final String name;
+
+        ArrowStyle(String name) { this.name = name; }
+        @Override
+        public final String getName() { return name; }
+        static public ArrowStyle toEnum(String name)  { return map.get(name.toLowerCase()); }
     }
 
     /**
@@ -212,6 +228,9 @@ public final class StyleProperties
             case ARROW -> {
                 return new StyleProperty(name, toArrow(value), definition);
             }
+            case ARROW_STYLE -> {
+                return new StyleProperty(name, toArrowStyle(value), definition);
+            }
             case EVENT_SHAPE -> {
                 return new StyleProperty(name, toEventShape(value), definition);
             }
@@ -263,16 +282,31 @@ public final class StyleProperties
     }
 
     /**
-     * Convert a token value to an Arrow type.
+     * Convert a token value to an Arrow position.
      *
      * @param value The token value.
      *
-     * @return The corresponding Arrow type.
+     * @return The corresponding Arrow position.
      */
     static public StyleProperties.Arrow toArrow(Token<?> value)
     {
         if (value.isName()) {
             return StyleProperties.Arrow.toEnum(value.getString());
+        }
+        return null;
+    }
+
+    /**
+     * Convert a token value to an Arrow style.
+     *
+     * @param value The token value.
+     *
+     * @return The corresponding Arrow style.
+     */
+    static public StyleProperties.ArrowStyle toArrowStyle(Token<?> value)
+    {
+        if (value.isName()) {
+            return StyleProperties.ArrowStyle.toEnum(value.getString());
         }
         return null;
     }

--- a/src/main/java/org/freixas/gamma/css/value/StyleProperty.java
+++ b/src/main/java/org/freixas/gamma/css/value/StyleProperty.java
@@ -37,7 +37,7 @@ public final class StyleProperty
         FLOAT, STRING, COLOR, BOOLEAN,
         LINE_STYLE,
         FONT_WEIGHT, FONT_STYLE, TEXT_ANCHOR,
-        ARROW, EVENT_SHAPE,
+        ARROW, ARROW_STYLE, EVENT_SHAPE,
         FONT
     }
 

--- a/src/main/java/org/freixas/gamma/css/value/StylePropertyDefinition.java
+++ b/src/main/java/org/freixas/gamma/css/value/StylePropertyDefinition.java
@@ -224,6 +224,7 @@ public final class StylePropertyDefinition
     static final StylePropertyDefinition opacity = new StylePropertyDefinition("opacity", fieldMap.get("opacity"), StyleProperty.Type.FLOAT, Min.EQ0);
 
     static final StylePropertyDefinition arrow = new StylePropertyDefinition("arrow", fieldMap.get("arrow"), StyleProperty.Type.ARROW);
+    static final StylePropertyDefinition arrowStyle = new StylePropertyDefinition("arrow-style", fieldMap.get("arrowStyle"), StyleProperty.Type.ARROW_STYLE);
     static final StylePropertyDefinition arrowWidth = new StylePropertyDefinition("arrow-width", fieldMap.get("arrowWidth"), StyleProperty.Type.FLOAT, Min.GT0);
     static final StylePropertyDefinition arrowHeight = new StylePropertyDefinition("arrow-height", fieldMap.get("arrowHeight"), StyleProperty.Type.FLOAT, Min.GT0);
 
@@ -338,6 +339,7 @@ public final class StylePropertyDefinition
         defMap.put("opacity", opacity);
 
         defMap.put("arrow", arrow);
+        defMap.put("arrow-style", arrowStyle);
         defMap.put("arrow-width", arrowWidth);
         defMap.put("arrow-height", arrowHeight);
 

--- a/src/main/java/org/freixas/gamma/css/value/StyleStruct.java
+++ b/src/main/java/org/freixas/gamma/css/value/StyleStruct.java
@@ -108,9 +108,9 @@ public class StyleStruct
 
     public double opacity = 1.0;
     public StyleProperties.Arrow arrow = StyleProperties.Arrow.NONE;
-    // Future:
-    // public double arrowWidth = 10.0;
-    // public double arrowHeight = 8.0;
+    public StyleProperties.ArrowStyle arrowStyle = StyleProperties.ArrowStyle.OPEN;
+    public double arrowWidth = 10.0;
+    public double arrowHeight = 8.0;
     public double eventDiameter = 5.0;
     public StyleProperties.EventShape eventShape = StyleProperties.EventShape.CIRCLE;
 }

--- a/src/main/java/org/freixas/gamma/drawing/Arrow.java
+++ b/src/main/java/org/freixas/gamma/drawing/Arrow.java
@@ -16,6 +16,7 @@
  */
 package org.freixas.gamma.drawing;
 
+import javafx.scene.shape.FillRule;
 import org.freixas.gamma.css.value.StyleStruct;
 import org.freixas.gamma.value.Bounds;
 import org.freixas.gamma.value.Coordinate;
@@ -30,9 +31,6 @@ import javafx.scene.transform.Affine;
  */
 public class Arrow
 {
-    public final static double ARROW_WIDTH = 10;
-    public final static double ARROW_HEIGHT = 8;
-
     /**
      * Draw an arrowhead.
      *
@@ -60,8 +58,8 @@ public class Arrow
         // Create a bounding box for the arrow and see if it intersects with the
         // viewport
 
-        double arrowWidth = ARROW_WIDTH * context.invScale;
-        double halfArrowHeight = ARROW_HEIGHT * context.invScale;
+        double arrowWidth = styles.arrowWidth * context.invScale;
+        double halfArrowHeight = styles.arrowHeight * context.invScale;
 
         double minX = location.x - arrowWidth;
         double minT = location.t - halfArrowHeight;
@@ -79,14 +77,52 @@ public class Arrow
             Line.setupLineGc(context, styles);
             gc.setLineJoin(StrokeLineJoin.MITER);
 
-            // Draw the arrow head
+            switch (styles.arrowStyle) {
 
-            gc.beginPath();
-            gc.moveTo(minX, minT);
-            gc.lineTo(location.x, location.t);
-            gc.lineTo(minX, maxT);
+                case OPEN -> {
+                    gc.beginPath();
+                    gc.moveTo(minX, minT);
+                    gc.lineTo(location.x, location.t);
+                    gc.lineTo(minX, maxT);
 
-            gc.stroke();
+                    gc.stroke();
+                }
+
+                case CLOSED -> {
+                    gc.beginPath();
+                    gc.moveTo(minX, minT);
+                    gc.lineTo(location.x, location.t);
+                    gc.lineTo(minX, maxT);
+                    gc.closePath();
+
+                    gc.stroke();
+                }
+
+                case FILLED -> {
+                    gc.beginPath();
+                    gc.moveTo(minX, minT);
+                    gc.lineTo(location.x, location.t);
+                    gc.lineTo(minX, maxT);
+                    gc.closePath();
+
+                    gc.setFillRule(FillRule.EVEN_ODD);
+                    gc.setFill(styles.color);
+                    gc.fill();
+                }
+
+                case CHEVRON -> {
+                    gc.beginPath();
+                    gc.moveTo(minX, minT);
+                    gc.lineTo(location.x, location.t);
+                    gc.lineTo(minX, maxT);
+                    gc.lineTo(minX + (location.x - minX)/3, location.t);
+                    gc.closePath();
+
+                    gc.setFillRule(FillRule.EVEN_ODD);
+                    gc.setFill(styles.color);
+                    gc.fill();
+                }
+            }
         }
 
         // Restore the original graphics context


### PR DESCRIPTION
Fixes #5: arrow-style property added.
Fixes #60: The arrow-width and arrow-height properties now work.
Documentation updated to include arrow-style, but also had various typos fixed.
The README.md and workflow files were updated for 1.0.4 and v1.0.4-RC1.